### PR TITLE
Update newspaper-api to latest master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM checksum/python-newspaper:latest
+FROM python:3.7.0-stretch
 
-RUN apk --update add linux-headers
+#Temporarily use Nuno's fork until it is merged to the main project
+RUN git clone https://github.com/NunoPinheiro/newspaper.git && \
+    cd newspaper && pip install -r requirements.txt
+
 RUN pip install --no-cache-dir flask uwsgi
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.7-stretch
+FROM python:3.7-slim
+
+RUN apt-get update && \
+    apt-get -y install gcc git
 
 RUN pip install --no-cache-dir flask uwsgi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.7.0-stretch
 
-#Temporarily use Nuno's fork until it is merged to the main project
-RUN git clone https://github.com/NunoPinheiro/newspaper.git && \
-    cd newspaper && pip install -r requirements.txt
-
 RUN pip install --no-cache-dir flask uwsgi
+
+#Clone newspaper project and checkout specific commit
+RUN git clone https://github.com/codelucas/newspaper.git && \
+    cd newspaper && git checkout 9af47d1e25f79720e4d9a48ca83debf1db821b5e \
+    && pip install -r requirements.txt
 
 COPY . .
 ENV NEWSPAPER_PORT 38765

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.0-stretch
+FROM python:3.7-stretch
 
 RUN pip install --no-cache-dir flask uwsgi
 

--- a/src/wsgi.ini
+++ b/src/wsgi.ini
@@ -9,3 +9,4 @@ vacuum = true
 callable = app
 socket = 0.0.0.0:38765
 protocol = http
+pythonpath = /newspaper


### PR DESCRIPTION
Changed docker file to clone newspaper project instead of using old image.
I set the specific commit so we can re-use the docker file and always generate the same newspaper version (instead of just pointing to master)