### PR TITLE
Fix: skip downloading PDF resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --no-cache-dir flask uwsgi
 
 #Clone newspaper project and checkout specific commit
 RUN git clone https://github.com/codelucas/newspaper.git && \
-    cd newspaper && git checkout 9af47d1e25f79720e4d9a48ca83debf1db821b5e \
+    cd newspaper && git checkout 11cbf3a3038c0630d14e55743b942b6f36624a6b \
     && pip install -r requirements.txt
 
 COPY . .

--- a/src/server.py
+++ b/src/server.py
@@ -44,7 +44,11 @@ def is_content_pdf(url):
 
 
 def get_article(url):
-    article = Article(url, request_timeout=20)
+    pdf_defaults = {"application/pdf": "%PDF-",
+                    "application/x-pdf": "%PDF-",
+                    "application/x-bzpdf": "%PDF-",
+                    "application/x-gzpdf": "%PDF-"}
+    article = Article(url, request_timeout=20, ignored_content_types_defaults=pdf_defaults)
     article.download()
     # uncomment this if 200 is desired in case of bad url
     # article.set_html(article.html if article.html else '<html></html>')

--- a/src/server.py
+++ b/src/server.py
@@ -3,17 +3,6 @@
 from flask import Flask, url_for, request
 from newspaper import Article
 import os, json
-import requests
-
-EMPTY_PDF_RESPONSE = json.dumps(
-    {"authors": '',
-     "html": '%PDF-',
-     "images:": [],
-     "movies": [],
-     "publish_date": '',
-     "text": '',
-     "title": '',
-     "topimage": ''}), 200, {'Content-Type': 'application/json'}
 
 app = Flask(__name__)
 import logging
@@ -24,8 +13,6 @@ log.setLevel(logging.ERROR)
 @app.route('/topimage',methods = ['GET'])
 def api_top_image():
     url = request.args.get('url')
-    if is_content_pdf(url):
-        return EMPTY_PDF_RESPONSE
     article = get_article(url)
     return json.dumps({
         "authors": article.authors,
@@ -36,12 +23,6 @@ def api_top_image():
         "text": article.text,
         "title": article.title,
         "topimage": article.top_image}), 200, {'Content-Type': 'application/json'}
-
-
-def is_content_pdf(url):
-    response = requests.head(url)
-    return response.headers['Content-Type'] == 'application/pdf'
-
 
 def get_article(url):
     pdf_defaults = {"application/pdf": "%PDF-",

--- a/src/server.py
+++ b/src/server.py
@@ -3,6 +3,17 @@
 from flask import Flask, url_for, request
 from newspaper import Article
 import os, json
+import requests
+
+EMPTY_PDF_RESPONSE = json.dumps(
+    {"authors": '',
+     "html": '%PDF-',
+     "images:": [],
+     "movies": [],
+     "publish_date": '',
+     "text": '',
+     "title": '',
+     "topimage": ''}), 200, {'Content-Type': 'application/json'}
 
 app = Flask(__name__)
 import logging
@@ -13,6 +24,8 @@ log.setLevel(logging.ERROR)
 @app.route('/topimage',methods = ['GET'])
 def api_top_image():
     url = request.args.get('url')
+    if is_content_pdf(url):
+        return EMPTY_PDF_RESPONSE
     article = get_article(url)
     return json.dumps({
         "authors": article.authors,
@@ -23,6 +36,12 @@ def api_top_image():
         "text": article.text,
         "title": article.title,
         "topimage": article.top_image}), 200, {'Content-Type': 'application/json'}
+
+
+def is_content_pdf(url):
+    response = requests.head(url)
+    return response.headers['Content-Type'] == 'application/pdf'
+
 
 def get_article(url):
     article = Article(url, request_timeout=20)


### PR DESCRIPTION
Check 'content-type' header of the resource before downloading it; return empty response in case of PDF type
