### PR TITLE
Exclude pdf file from build

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -86,7 +86,7 @@ def get_article(url, config = Config()):
     # uncomment this if 200 is desired in case of bad url
     # article.set_html(article.html if article.html else '<html></html>')
     article.parse()
-    if article.text == "":
+    if article.text == "" and article.html != "%PDF-":
         paper = build(url, memoize_articles=False, fetch_images=False)
         article.text = paper.description
     return article


### PR DESCRIPTION
For smarpers/smarpshare#8310, while PDF file doesn't need to be built, it takes a long time to build, due to file size, and causes time out error. We simply ignore it.